### PR TITLE
Switch export_glpi_printer_connections to ContractDevice

### DIFF
--- a/inventory/management/commands/export_glpi_printer_connections.py
+++ b/inventory/management/commands/export_glpi_printer_connections.py
@@ -1,10 +1,10 @@
 """
-Экспорт принтеров в Excel с дополнительными колонками "В GLPI" и "Подключён к ПК".
+Экспорт устройств по договору (ContractDevice) в Excel с дополнительными
+колонками "В GLPI" и "Подключён к ПК".
 
-Команда идёт в GLPI API по серийному номеру каждого принтера, читает вкладку
+Команда идёт в GLPI API по серийному номеру каждого устройства, читает вкладку
 "Подключение" (Computer_Item) и собирает список ПК, к которым этот принтер
-привязан в GLPI. Итог — xlsx с тем же набором колонок, что у веб-экспорта
-inventory.views.export_views.export_excel, плюс:
+привязан в GLPI. Итог — xlsx с колонками со страницы /contracts/ плюс:
     - "В GLPI"          — статус поиска (FOUND_SINGLE / FOUND_MULTIPLE / NOT_FOUND / ERROR)
     - "Кол-во ПК"       — сколько компьютеров подключено к принтеру
     - "ПК (имя | IP | serial)" — перечисление через "; "
@@ -25,52 +25,28 @@ from openpyxl.styles import Font
 from openpyxl.utils import get_column_letter
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils import timezone
-from django.utils.timezone import localtime
 
+from contracts.models import ContractDevice
 from integrations.glpi.client import GLPIAPIError, GLPIClient
-from inventory.models import InventoryTask, Printer
-from inventory.services import get_printer_inventory_status
 
 logger = logging.getLogger(__name__)
 
 HEADERS = [
     "Организация",
-    "IP-адрес",
-    "Серийный №",
-    "MAC-адрес",
+    "Город",
+    "Адрес",
+    "№ кабинета",
     "Производитель",
     "Модель",
-    "ЧБ A4",
-    "Цвет A4",
-    "ЧБ A3",
-    "Цвет A3",
-    "Всего",
-    "Тонер K",
-    "Тонер C",
-    "Тонер M",
-    "Тонер Y",
-    "Барабан K",
-    "Барабан C",
-    "Барабан M",
-    "Барабан Y",
-    "Fuser Kit",
-    "Transfer Kit",
-    "Waste Toner",
-    "Правило",
-    "Дата последнего опроса",
-    "Статус последнего опроса",
-    "Последняя ошибка",
+    "Серийный №",
+    "Статус договора",
+    "Месяц принятия",
+    "Сетевой порт",
+    "IP-адрес",
     "В GLPI",
     "Кол-во ПК",
     "ПК (имя | IP | serial)",
 ]
-
-RULE_LABEL = {
-    "SN_MAC": "Серийник+MAC",
-    "MAC_ONLY": "Только MAC",
-    "SN_ONLY": "Только серийник",
-}
 
 GLPI_STATUS_LABEL = {
     "FOUND_SINGLE": "Найден",
@@ -93,7 +69,7 @@ def _format_computers(computers):
 
 
 class Command(BaseCommand):
-    help = "Экспорт принтеров в Excel с колонкой подключений к ПК из GLPI."
+    help = "Экспорт устройств по договору в Excel с колонкой подключений к ПК из GLPI."
 
     def add_arguments(self, parser):
         parser.add_argument("output", help="Путь к выходному .xlsx файлу")
@@ -101,7 +77,7 @@ class Command(BaseCommand):
             "--limit",
             type=int,
             default=0,
-            help="Ограничить число принтеров (0 = без ограничения). Удобно для теста.",
+            help="Ограничить число устройств (0 = без ограничения). Удобно для теста.",
         )
         parser.add_argument(
             "--organization",
@@ -111,7 +87,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--only-with-serial",
             action="store_true",
-            help="Пропустить принтеры без серийного номера (в GLPI их всё равно не найти).",
+            help="Пропустить устройства без серийного номера (в GLPI их всё равно не найти).",
         )
         parser.add_argument(
             "--rate-limit",
@@ -126,11 +102,14 @@ class Command(BaseCommand):
             raise CommandError("Файл должен иметь расширение .xlsx")
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        qs = (
-            Printer.objects.filter(is_active=True)
-            .select_related("organization", "device_model", "device_model__manufacturer")
-            .order_by("ip_address")
-        )
+        qs = ContractDevice.objects.select_related(
+            "organization",
+            "city",
+            "model",
+            "model__manufacturer",
+            "status",
+            "printer",
+        ).order_by("organization__name", "city__name", "address", "room_number")
 
         if opts["organization"]:
             qs = qs.filter(organization__name__icontains=opts["organization"])
@@ -141,39 +120,40 @@ class Command(BaseCommand):
 
         total = qs.count()
         if not total:
-            self.stdout.write(self.style.WARNING("Принтеров для экспорта не найдено."))
+            self.stdout.write(self.style.WARNING("Устройств для экспорта не найдено."))
             return
 
-        self.stdout.write(f"Принтеров к обработке: {total}")
+        self.stdout.write(f"Устройств к обработке: {total}")
 
         wb = openpyxl.Workbook()
         ws = wb.active
-        ws.title = "Printers + GLPI PC"
+        ws.title = "Contracts + GLPI PC"
 
         for col_idx, header in enumerate(HEADERS, 1):
             cell = ws.cell(row=1, column=col_idx, value=header)
             cell.font = Font(bold=True)
 
         col_widths = [len(h) for h in HEADERS]
-        date_col_idx = HEADERS.index("Дата последнего опроса") + 1
 
-        stats = {"found_single": 0, "found_multiple": 0, "not_found": 0, "errors": 0, "no_serial": 0, "with_pc": 0}
+        stats = {
+            "found_single": 0,
+            "found_multiple": 0,
+            "not_found": 0,
+            "errors": 0,
+            "no_serial": 0,
+            "with_pc": 0,
+        }
         rate_limit = opts["rate_limit"]
 
         try:
             with GLPIClient() as client:
-                for idx, printer in enumerate(qs, 1):
-                    glpi_status_label, computers = self._query_glpi(client, printer, stats)
-                    row_values = self._build_row(printer, glpi_status_label, computers)
+                for idx, device in enumerate(qs, 1):
+                    glpi_status_label, computers = self._query_glpi(client, device, stats)
+                    row_values = self._build_row(device, glpi_status_label, computers)
 
                     for col_idx, val in enumerate(row_values, 1):
                         cell = ws.cell(row=idx + 1, column=col_idx, value=val)
-                        if col_idx == date_col_idx and val:
-                            cell.number_format = "dd.mm.yyyy hh:mm"
-
                         disp = val if val is not None else ""
-                        if hasattr(val, "strftime"):
-                            disp = val.strftime("%d.%m.%Y %H:%M")
                         col_widths[col_idx - 1] = max(col_widths[col_idx - 1], len(str(disp)))
 
                     if computers:
@@ -200,20 +180,20 @@ class Command(BaseCommand):
         self.stdout.write(
             f"  Не найдено: {stats['not_found']}, без серийника: {stats['no_serial']}, " f"ошибок: {stats['errors']}"
         )
-        self.stdout.write(f"  Принтеров с подключёнными ПК: {stats['with_pc']}")
+        self.stdout.write(f"  Устройств с подключёнными ПК: {stats['with_pc']}")
 
     # ──────────────────────────────────────────────────────────────────
     # Внутренние помощники
     # ──────────────────────────────────────────────────────────────────
 
-    def _query_glpi(self, client, printer, stats):
+    def _query_glpi(self, client, device, stats):
         """
-        Ищет принтер в GLPI по серийнику и тянет подключённые компьютеры.
+        Ищет устройство в GLPI по серийнику и тянет подключённые компьютеры.
 
         Returns:
             (label, computers) — human-readable статус и список dict про ПК.
         """
-        serial = (printer.serial_number or "").strip()
+        serial = (device.serial_number or "").strip()
         if not serial:
             stats["no_serial"] += 1
             return GLPI_STATUS_LABEL["NO_SERIAL"], []
@@ -237,7 +217,7 @@ class Command(BaseCommand):
         elif status == "FOUND_MULTIPLE":
             stats["found_multiple"] += 1
 
-        # Собираем ПК со всех найденных GLPI-карточек принтера (на случай дубликатов)
+        # Собираем ПК со всех найденных GLPI-карточек (на случай дубликатов)
         computers = []
         seen_ids = set()
         for item in items:
@@ -258,60 +238,27 @@ class Command(BaseCommand):
 
         return GLPI_STATUS_LABEL.get(status, status), computers
 
-    def _build_row(self, p, glpi_status_label, computers):
+    def _build_row(self, device, glpi_status_label, computers):
         """Возвращает значения для одной строки xlsx, в порядке HEADERS."""
-        inv_status = get_printer_inventory_status(p.id)
-        counters = inv_status.get("counters", {})
-
-        dt_value = None
-        if inv_status.get("timestamp"):
-            try:
-                dt = timezone.datetime.fromisoformat(inv_status["timestamp"].replace("Z", "+00:00"))
-                dt_value = localtime(dt).replace(tzinfo=None)
-            except Exception:
-                pass
-
-        last_task = InventoryTask.objects.filter(printer=p).order_by("-task_timestamp").first()
-        if last_task:
-            try:
-                status_map = dict(InventoryTask.STATUS_CHOICES)
-                last_status = status_map.get(last_task.status, last_task.status or "—")
-            except Exception:
-                last_status = last_task.status or "—"
-        else:
-            last_status = "—"
-
-        last_error = ""
-        if last_task and last_task.status in ("FAILED", "VALIDATION_ERROR", "HISTORICAL_INCONSISTENCY"):
-            last_error = (last_task.error_message or "")[:100]
+        model = device.model
+        manufacturer_name = getattr(model.manufacturer, "name", "—") if model and model.manufacturer_id else "—"
+        model_name = model.name if model else "—"
+        has_network_port = bool(getattr(model, "has_network_port", False)) if model else False
+        printer = device.printer
+        ip_address = printer.ip_address if printer else ""
 
         return [
-            p.organization.name if p.organization_id else "—",
-            p.ip_address,
-            p.serial_number,
-            p.mac_address or "",
-            getattr(p.device_model.manufacturer, "name", "—") if p.device_model_id else "—",
-            p.model_display,
-            counters.get("bw_a4", ""),
-            counters.get("color_a4", ""),
-            counters.get("bw_a3", ""),
-            counters.get("color_a3", ""),
-            counters.get("total_pages", ""),
-            counters.get("toner_black", ""),
-            counters.get("toner_cyan", ""),
-            counters.get("toner_magenta", ""),
-            counters.get("toner_yellow", ""),
-            counters.get("drum_black", ""),
-            counters.get("drum_cyan", ""),
-            counters.get("drum_magenta", ""),
-            counters.get("drum_yellow", ""),
-            counters.get("fuser_kit", ""),
-            counters.get("transfer_kit", ""),
-            counters.get("waste_toner", ""),
-            RULE_LABEL.get(p.last_match_rule, "—"),
-            dt_value,
-            last_status,
-            last_error,
+            device.organization.name if device.organization_id else "—",
+            device.city.name if device.city_id else "—",
+            device.address or "",
+            device.room_number or "",
+            manufacturer_name,
+            model_name,
+            device.serial_number or "",
+            device.status.name if device.status_id else "—",
+            device.service_start_month_display,
+            "да" if has_network_port else "нет",
+            ip_address,
             glpi_status_label,
             len(computers),
             _format_computers(computers),


### PR DESCRIPTION
Команда теперь обходит ContractDevice (все устройства со страницы /contracts/), а не только инвентарные Printer. Колонки приведены к набору со страницы /contracts/ + GLPI-блок: Организация, Город, Адрес, № кабинета, Производитель, Модель, Серийный №, Статус договора, Месяц принятия, Сетевой порт, IP-адрес (если есть связанный Printer), В GLPI, Кол-во ПК, ПК (имя | IP | serial).

Why: на /contracts/ есть устройства без Printer (USB/неподключаемые), которые раньше команда не видела.